### PR TITLE
Add HTTP response checks

### DIFF
--- a/lib/provider/app_pages_provider/details_provider.dart
+++ b/lib/provider/app_pages_provider/details_provider.dart
@@ -120,6 +120,10 @@ class DetailsProvider with ChangeNotifier {
             "${api().link}/favorite-lists/$wishlist_id/products/$product_id"),
         headers: headers,
       );
+      if (response.statusCode != 200) {
+        debugPrint('❌ Remove wishlist failed: ${response.statusCode}');
+        return;
+      }
       print(response.body);
     } else {
       //geting user id and token from stored database
@@ -138,6 +142,10 @@ class DetailsProvider with ChangeNotifier {
             "${api().link}/favorite-lists/$wishlist_id/products/$product_id"),
         headers: headers,
       );
+      if (resposne.statusCode != 200) {
+        debugPrint('❌ Add to wishlist failed: ${resposne.statusCode}');
+        return;
+      }
       print(resposne.body);
     }
     is_Wished = !is_Wished;
@@ -219,7 +227,10 @@ class DetailsProvider with ChangeNotifier {
         Uri.parse("${api().link}/products/$product_id/reviews"),
         headers: headers,
         body: body);
-
     Navigator.pop(context);
+    if (response.statusCode != 200) {
+      debugPrint('❌ Add review failed: ${response.statusCode}');
+      return;
+    }
   }
 }

--- a/lib/provider/app_pages_provider/filter_provider.dart
+++ b/lib/provider/app_pages_provider/filter_provider.dart
@@ -51,6 +51,10 @@ class FilterProvider with ChangeNotifier {
     //color
     var responseColors =
         await http.get(Uri.parse("${api().link}/colors"), headers: headers);
+    if (responseColors.statusCode != 200) {
+      debugPrint('❌ Failed to load colors: ${responseColors.statusCode}');
+      return;
+    }
     var colors = json.decode(responseColors.body);
 
     var readyColors = colors["data"].map((map) {
@@ -70,6 +74,11 @@ class FilterProvider with ChangeNotifier {
     //departement
     var responseDepartments = await http
         .get(Uri.parse("${api().link}/departments"), headers: headers);
+    if (responseDepartments.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load departments: ${responseDepartments.statusCode}');
+      return;
+    }
     var departments = json.decode(responseDepartments.body);
 
     var departmentsReady = departments["data"].map((map) {
@@ -84,6 +93,11 @@ class FilterProvider with ChangeNotifier {
     var responseCategories = await http.get(
         Uri.parse("${api().link}/categories?countSubCategoriesProducts=true"),
         headers: headers);
+    if (responseCategories.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load categories: ${responseCategories.statusCode}');
+      return;
+    }
     var categories = json.decode(responseCategories.body);
     categoriesJsonData = categories["data"];
     categoriesReady = categories["data"].map<DropdownMenuItem<String>>((value) {
@@ -96,6 +110,10 @@ class FilterProvider with ChangeNotifier {
     //cities
     var responseCities =
         await http.get(Uri.parse("${api().link}/cities"), headers: headers);
+    if (responseCities.statusCode != 200) {
+      debugPrint('❌ Failed to load cities: ${responseCities.statusCode}');
+      return;
+    }
     var cities = json.decode(responseCities.body);
     var citiesReady = cities["data"].map((map) {
       if (map.containsKey("title")) {
@@ -108,6 +126,10 @@ class FilterProvider with ChangeNotifier {
     //styles
     var responseStyles =
         await http.get(Uri.parse("${api().link}/styles"), headers: headers);
+    if (responseStyles.statusCode != 200) {
+      debugPrint('❌ Failed to load styles: ${responseStyles.statusCode}');
+      return;
+    }
     var styles = json.decode(responseStyles.body);
     var stylesReady = styles["data"].map((map) {
       if (map.containsKey("title")) {
@@ -120,6 +142,10 @@ class FilterProvider with ChangeNotifier {
     //companies
     var responseCompanies =
         await http.get(Uri.parse("${api().link}/companies"), headers: headers);
+    if (responseCompanies.statusCode != 200) {
+      debugPrint('❌ Failed to load companies: ${responseCompanies.statusCode}');
+      return;
+    }
     var companies = json.decode(responseCompanies.body);
     var companiesReady = companies["data"].map((map) {
       if (map.containsKey("title")) {
@@ -132,6 +158,10 @@ class FilterProvider with ChangeNotifier {
     //sizes
     var responseSizes =
         await http.get(Uri.parse("${api().link}/sizes"), headers: headers);
+    if (responseSizes.statusCode != 200) {
+      debugPrint('❌ Failed to load sizes: ${responseSizes.statusCode}');
+      return;
+    }
     var sizes = json.decode(responseSizes.body);
     var sizesReady = sizes["data"].map((map) {
       if (map.containsKey("title")) {
@@ -160,6 +190,11 @@ class FilterProvider with ChangeNotifier {
     var responsePriceRange = await http.get(
         Uri.parse("${api().link}/products/price-pair"),
         headers: price_headers);
+    if (responsePriceRange.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load price range: ${responsePriceRange.statusCode}');
+      return;
+    }
     var priceRange = json.decode(responsePriceRange.body);
     print(priceRange);
     min = double.parse(priceRange["min"]);
@@ -422,6 +457,11 @@ class FilterProvider with ChangeNotifier {
 
 
     var response = await http.get(url, headers: headers);
+    if (response.statusCode != 200) {
+      debugPrint('❌ Failed to load filtered products: ${response.statusCode}');
+      Navigator.pop(context);
+      return;
+    }
     var products = json.decode(response.body)["data"];
     if (products.length == 0) {
       products = [
@@ -470,6 +510,12 @@ class FilterProvider with ChangeNotifier {
     var responseSubCategories = await http.get(
         Uri.parse("${api().link}/categories/$category_id/sub-categories"),
         headers: headers);
+    if (responseSubCategories.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load sub-categories: ${responseSubCategories.statusCode}');
+      Navigator.pop(context);
+      return;
+    }
 
     var subCategories = json.decode(responseSubCategories.body);
     subcategoriesJsonData = subCategories["data"];

--- a/lib/provider/auth_provider/forgot_provider.dart
+++ b/lib/provider/auth_provider/forgot_provider.dart
@@ -48,6 +48,11 @@ class ForgotProvider with ChangeNotifier {
       };
       var response = await http.post(Uri.parse("${api().link}/forget-password"),
           headers: headers, body: body);
+      if (response.statusCode != 200) {
+        debugPrint('❌ Forgot password request failed: ${response.statusCode}');
+        Navigator.pop(context);
+        return;
+      }
       var messsage = json.decode(response.body);
       print(messsage.toString());
       Navigator.pop(context);

--- a/lib/provider/auth_provider/registration_provider.dart
+++ b/lib/provider/auth_provider/registration_provider.dart
@@ -61,6 +61,13 @@ class RegistrationProvider with ChangeNotifier {
     if (Navigator.canPop(loadingContext)) {
       Navigator.pop(loadingContext);
     }
+    if (response.statusCode != 200) {
+      debugPrint('❌ Registration failed: ${response.statusCode}');
+      showDialog(
+          context: context,
+          builder: (context) => BlurryErorrAuthDialog());
+      return;
+    }
     try {
       print(response.body);
       var data = await json.decode(response.body);

--- a/lib/provider/bottom_provider/department_category_provider.dart
+++ b/lib/provider/bottom_provider/department_category_provider.dart
@@ -39,6 +39,11 @@ class CategoryProvider with ChangeNotifier {
     final apiLink =
         Uri.parse("${api().link}/departments/$department_id/categories");
     var categories = await http.get(apiLink, headers: headers);
+    if (categories.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load categories: ${categories.statusCode}');
+      return;
+    }
 
     //returning the category data in the right format
     List<dynamic> catObj =
@@ -84,6 +89,10 @@ class CategoryProvider with ChangeNotifier {
     };
     final apiLink = Uri.parse("${api().link}/departments");
     var categories = await http.get(apiLink, headers: headers);
+    if (categories.statusCode != 200) {
+      debugPrint('❌ Failed to load departments: ${categories.statusCode}');
+      return;
+    }
 
     //returning the category data in the right format
     var catObj = json.decode(categories.body.toString());
@@ -113,6 +122,10 @@ class CategoryProvider with ChangeNotifier {
     };
     final apiLink = Uri.parse("${api().link}/categories?page=$page");
     var categories = await http.get(apiLink, headers: headers);
+    if (categories.statusCode != 200) {
+      debugPrint('❌ Failed to load more categories: ${categories.statusCode}');
+      return false;
+    }
     var catObj = json.decode(categories.body.toString());
     appArray.categories.addAll(catObj["data"]);
     notifyListeners();
@@ -155,6 +168,11 @@ class CategoryProvider with ChangeNotifier {
       final apiLink = Uri.parse(
           "${api().link}/products?created_at[sort]=asc&favoriteListsInfo=true&contactDetails=true");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint(
+            '❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "TrendFurnitureList") {
       //adding current language to header of api call and gettig the data
@@ -162,6 +180,11 @@ class CategoryProvider with ChangeNotifier {
       final apiLink = Uri.parse(
           "${api().link}/products?view[sort]=desc&favoriteListsInfo=true&contactDetails=true");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint(
+            '❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "OfferZoneList") {
       //adding current language to header of api call and gettig the data
@@ -169,6 +192,11 @@ class CategoryProvider with ChangeNotifier {
       final apiLink = Uri.parse(
           "${api().link}/products?onSale=true&favoriteListsInfo=true&contactDetails=true");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint(
+            '❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "BestSellingList") {
       //adding current language to header of api call and gettig the data
@@ -176,36 +204,67 @@ class CategoryProvider with ChangeNotifier {
       final apiLink = Uri.parse(
           "${api().link}/products?favoriteListsInfo=true&contactDetails=true&contactDetails=true");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint(
+            '❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "SearchList") {
       final apiLink =
           Uri.parse("${api().link}/products?search[like]=$searchTerm");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint(
+            '❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "subCategory") {
       final apiLink = Uri.parse(
           "${api().link}/categories/$sub_category_id/products?favoriteListsInfo=true&contactDetails=true");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint(
+            '❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "Category") {
       //adding current language to header of api call and gettig the data
       final apiSubCategoryLink =
           Uri.parse("${api().link}/categories/$index/sub-categories");
       var subCategories = await http.get(apiSubCategoryLink, headers: headers);
+      if (subCategories.statusCode != 200) {
+        debugPrint('❌ Failed to load sub-categories: ${subCategories.statusCode}');
+        return;
+      }
       subCategoriesObj = json.decode(subCategories.body.toString())["data"];
 
       //
       final apiLink = Uri.parse(
           "${api().link}/categories/$index/products?favoriteListsInfo=true&contactDetails=true");
       var categoriesProduct = await http.get(apiLink, headers: headers);
+      if (categoriesProduct.statusCode != 200) {
+        debugPrint('❌ Failed to load products: ${categoriesProduct.statusCode}');
+        return;
+      }
       catObj = json.decode(categoriesProduct.body.toString());
     } else if (others == "SalesScreen") {
       final apiLink = Uri.parse("${api().link}/sales/$sales_id/products");
       var categories = await http.get(apiLink, headers: headers);
+      if (categories.statusCode != 200) {
+        debugPrint('❌ Failed to load products: ${categories.statusCode}');
+        return;
+      }
       catObj = json.decode(categories.body.toString());
     } else if (others == "Show Room") {
       final apiLink = Uri.parse("${api().link}/showrooms/$sales_id/products");
       var categories = await http.get(apiLink, headers: headers);
+      if (categories.statusCode != 200) {
+        debugPrint('❌ Failed to load products: ${categories.statusCode}');
+        return;
+      }
 
       catObj = json.decode(categories.body.toString());
     } else {
@@ -214,6 +273,10 @@ class CategoryProvider with ChangeNotifier {
       final apiLink =
           Uri.parse("${api().link}/departments/$department_id/categories");
       var categories = await http.get(apiLink, headers: headers);
+      if (categories.statusCode != 200) {
+        debugPrint('❌ Failed to load categories: ${categories.statusCode}');
+        return;
+      }
       catObj = json.decode(categories.body.toString());
     }
 
@@ -302,6 +365,10 @@ class CategoryProvider with ChangeNotifier {
     final apiLink = Uri.parse(
         "${api().link}/categories/$category_id/products?favoriteListsInfo=true&contactDetails=true");
     var categoriesProduct = await http.get(apiLink, headers: headers);
+    if (categoriesProduct.statusCode != 200) {
+      debugPrint('❌ Failed to load products: ${categoriesProduct.statusCode}');
+      return;
+    }
     catObj = json.decode(categoriesProduct.body.toString());
 
     simmilarProductsList = catObj["data"]
@@ -331,6 +398,11 @@ class CategoryProvider with ChangeNotifier {
     final apiLink =
         Uri.parse("${api().link}/departments?search[like]=${searchCtrl.text}");
     var categoriesProduct = await http.get(apiLink, headers: headers);
+    if (categoriesProduct.statusCode != 200) {
+      debugPrint('❌ Department search failed: ${categoriesProduct.statusCode}');
+      searchCtrl.clear();
+      return;
+    }
     catObj = json.decode(categoriesProduct.body.toString());
     print(catObj);
     if (catObj["message"] != null) {

--- a/lib/provider/bottom_provider/home_provider.dart
+++ b/lib/provider/bottom_provider/home_provider.dart
@@ -52,8 +52,14 @@ class HomeProvider with ChangeNotifier {
       headers: headers,
     );
     print("📡 URL: ${api().link}/products?created_at[sort]=asc&...");
-print("🧾 Status Code: ${newArriablResponse.statusCode}");
-print("📦 Body: ${newArriablResponse.body}");
+    print("🧾 Status Code: ${newArriablResponse.statusCode}");
+    print("📦 Body: ${newArriablResponse.body}");
+
+    if (newArriablResponse.statusCode != 200) {
+      debugPrint(
+          "❌ Failed to load new arrivals: ${newArriablResponse.statusCode}");
+      return;
+    }
 
     var newArrivalResponse = await json.decode(newArriablResponse.body);
 
@@ -77,6 +83,11 @@ print("📦 Body: ${newArriablResponse.body}");
         Uri.parse(
             "${api().link}/products?view[sort]=desc&favoriteListsInfo=true&contactDetails=true"),
         headers: headers);
+    if (terndingResponse.statusCode != 200) {
+      debugPrint(
+          "❌ Failed to load trending furniture: ${terndingResponse.statusCode}");
+      return;
+    }
     var terndingData = await json.decode(terndingResponse.body);
 
     appArray.trendFurniture = terndingData["data"].sublist(
@@ -95,6 +106,11 @@ print("📦 Body: ${newArriablResponse.body}");
         Uri.parse(
             "${api().link}/products?onSale=true&favoriteListsInfo=true&contactDetails=true"),
         headers: headers);
+    if (offerResponse.statusCode != 200) {
+      debugPrint(
+          "❌ Failed to load offers: ${offerResponse.statusCode}");
+      return;
+    }
     var offerData = await json.decode(offerResponse.body);
 
     appArray.offerZone = offerData["data"].sublist(

--- a/lib/provider/bottom_provider/sales_provider.dart
+++ b/lib/provider/bottom_provider/sales_provider.dart
@@ -29,6 +29,10 @@ class SalesProvider with ChangeNotifier {
 
     final apiLink = Uri.parse("${api().link}/showrooms");
     var sales = await http.get(apiLink, headers: headers);
+    if (sales.statusCode != 200) {
+      debugPrint('❌ Failed to load showrooms: ${sales.statusCode}');
+      return;
+    }
     var salesObj = json.decode(sales.body.toString());
     salesObjects = salesObj["data"];
     if (salesObjects.length == 0) {

--- a/lib/provider/bottom_provider/wishlist_provider.dart
+++ b/lib/provider/bottom_provider/wishlist_provider.dart
@@ -24,6 +24,11 @@ class WishlistProvider with ChangeNotifier {
     var fovouriteIdResponse = await http.get(
         Uri.parse("${api().link}/customers/$id/favorite-lists"),
         headers: {"x-api-key": api().key, "Accept": "application/json"});
+    if (fovouriteIdResponse.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load wishlist: ${fovouriteIdResponse.statusCode}');
+      return;
+    }
     var favouriteIdJson = json.decode(fovouriteIdResponse.body);
 
     //adding the data to wishlist
@@ -136,6 +141,11 @@ class WishlistProvider with ChangeNotifier {
           'Authorization': 'Bearer $token',
           'Accept': 'application/json'
         });
+    if (fovouriteIdResponse.statusCode != 200) {
+      debugPrint(
+          '❌ Failed to load wishlist products: ${fovouriteIdResponse.statusCode}');
+      return;
+    }
     var favouriteJson = json.decode(fovouriteIdResponse.body);
     print(fovouriteIdResponse.body);
     //adding the data to wishlist


### PR DESCRIPTION
## Summary
- verify status codes before decoding API responses in providers
- log errors when the status code is not 200

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f70ee890832ea6b8617a007d292a