### PR TITLE
Add first-run language selector

### DIFF
--- a/lib/common/session.dart
+++ b/lib/common/session.dart
@@ -4,4 +4,5 @@ class Session {
   String isNotification = 'isNotification';
   String isLanguage = 'language_code';
   String isMode = 'isMode';
+  String isLanguageSelected = 'language_selected';
 }

--- a/lib/provider/auth_provider/splash_provider.dart
+++ b/lib/provider/auth_provider/splash_provider.dart
@@ -22,6 +22,7 @@ class SplashProvider with ChangeNotifier {
 
   controller!.forward().whenComplete(() async {
     final prefs = await SharedPreferences.getInstance();
+    final langSelected = prefs.getBool(session.isLanguageSelected) ?? false;
     final seenIntro = prefs.getBool('seen_intro') ?? false;
     final token = prefs.getString("token");
 
@@ -29,11 +30,13 @@ class SplashProvider with ChangeNotifier {
     prof.isGuest = token == null;
     prof.notifyListeners();
 
-    if (!seenIntro) {
-  route.pushNamed(context, routeName.onBoarding);
-} else {
-  route.pushNamed(context, routeName.dashboard); // ✅ always go to dashboard
-}
+    if (!langSelected) {
+      route.pushNamed(context, routeName.languageSelector);
+    } else if (!seenIntro) {
+      route.pushNamed(context, routeName.onBoarding);
+    } else {
+      route.pushNamed(context, routeName.dashboard);
+    }
 
   });
 

--- a/lib/routes/route_method.dart
+++ b/lib/routes/route_method.dart
@@ -4,6 +4,7 @@ import '../config.dart';
 class AppRoute {
   Map<String, Widget Function(BuildContext)> route = {
     routeName.splash: (p0) => const SplashScreen(),
+    routeName.languageSelector: (p0) => const LanguageSelectorScreen(),
     routeName.onBoarding: (p0) => const OnBoardingScreen(),
     routeName.login: (p0) => const LoginScreen(),
     routeName.registration: (p0) => const RegistrationPage(),

--- a/lib/routes/route_name.dart
+++ b/lib/routes/route_name.dart
@@ -1,6 +1,7 @@
 class RouteName {
   final String splash = '/';
   final String onBoarding = '/OnBoardingScreen';
+  final String languageSelector = '/LanguageSelectorScreen';
   final String login = "/LoginScreen";
   final String registration = "/RegistrationPage";
   final String forgot = "/ForgotScreen";

--- a/lib/screens/auth_screens/auth_path_list.dart
+++ b/lib/screens/auth_screens/auth_path_list.dart
@@ -1,5 +1,6 @@
 export 'package:kobin/screens/auth_screens/splash_screen/splash_screen.dart';
 export 'package:kobin/screens/auth_screens/onboarding_screen/onboarding_screen.dart';
+export 'package:kobin/screens/auth_screens/language_selector_screen/language_selector_screen.dart';
 export 'package:kobin/widgets/common_layout_text.dart';
 export 'package:kobin/screens/auth_screens/login_screen/login_screen.dart';
 export 'package:kobin/screens/auth_screens/registration_screen/registration_screen.dart';

--- a/lib/screens/auth_screens/language_selector_screen/language_selector_screen.dart
+++ b/lib/screens/auth_screens/language_selector_screen/language_selector_screen.dart
@@ -1,0 +1,73 @@
+import '../../../config.dart';
+import 'package:kobin/plugin_list.dart';
+
+class LanguageSelectorScreen extends StatelessWidget {
+  const LanguageSelectorScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<LanguageProvider>(builder: (context1, languageCtrl, child) {
+      return DirectionLayout(
+        dChild: Scaffold(
+          backgroundColor: appColor(context).appTheme.backGroundColorMain,
+          body: SafeArea(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const VSpace(Sizes.s20),
+                Center(
+                  child: Text(
+                    language(context, appFonts.language),
+                    style: appCss.dmPoppinsSemiBold20
+                        .textColor(isThemeColorReturn(context)),
+                  ),
+                ),
+                const VSpace(Sizes.s6),
+                Center(
+                  child: Text(
+                    language(context, appFonts.languageSubTitle),
+                    style: appCss.dmPoppinsRegular14
+                        .textColor(appColor(context).appTheme.txt),
+                  ),
+                ),
+                const VSpace(Sizes.s30),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: appArray.languageList
+                          .asMap()
+                          .entries
+                          .map(
+                            (e) => LanguageSubLayout(
+                              index: e.key,
+                              data: e.value,
+                            ).inkWell(
+                              onTap: () {
+                                languageCtrl
+                                    .changeLocale(e.value['title'].toString());
+                              },
+                            ),
+                          )
+                          .toList(),
+                    ).paddingSymmetric(horizontal: Insets.i20),
+                  ),
+                ),
+                ButtonCommon(
+                  title: language(context, appFonts.continueShopping),
+                  onTap: () async {
+                    final prefs = await SharedPreferences.getInstance();
+                    await prefs.setBool('language_selected', true);
+                    if (context.mounted) {
+                      Navigator.pushReplacementNamed(
+                          context, routeName.onBoarding);
+                    }
+                  },
+                ).paddingSymmetric(horizontal: Insets.i20, vertical: Insets.i20),
+              ],
+            ),
+          ),
+        ),
+      );
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `LanguageSelectorScreen`
- track whether the language was selected via `Session.isLanguageSelected`
- show `LanguageSelectorScreen` from splash when not yet chosen
- register the screen in routes and exports

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f4ec9888832ebe0b6d21f5e0ae5e